### PR TITLE
Add current-date anchoring for fitness plan generation

### DIFF
--- a/app/chat_module/gemini_client.py
+++ b/app/chat_module/gemini_client.py
@@ -7,10 +7,66 @@ We now implement those on top of the shared GeminiClient in
 `app.chatbot.gemini_client`.
 """
 
-from typing import Any, Dict, List
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
 import json
 
 from app.chatbot.gemini_client import GeminiClient as BaseGeminiClient
+
+
+def _day_key(entry: Dict[str, Any]) -> str:
+    d = entry.get("date_of_workout") or ""
+    return str(d)[:10]
+
+
+def _split_evenly(items: List[Dict[str, Any]], n: int) -> List[List[Dict[str, Any]]]:
+    if n <= 0:
+        return [items]
+    L = len(items)
+    if L == 0:
+        return []
+    base, extra = divmod(L, n)
+    chunks: List[List[Dict[str, Any]]] = []
+    idx = 0
+    for i in range(n):
+        sz = base + (1 if i < extra else 0)
+        chunks.append(items[idx : idx + sz])
+        idx += sz
+    return chunks
+
+
+def _renormalize_fitness_plan_dates(entries: List[Dict[str, Any]], start: date) -> None:
+    """
+    Force workout dates onto consecutive calendar days beginning at `start`.
+
+    The model often emits stale years; we treat its dates only as day-grouping hints
+    (same string = same day), then remap to [start, start+1, ...].
+    """
+    if not entries:
+        return
+
+    blocks: List[List[Dict[str, Any]]] = []
+    for e in entries:
+        if not blocks:
+            blocks.append([e])
+        elif _day_key(e) == _day_key(blocks[-1][0]):
+            blocks[-1].append(e)
+        else:
+            blocks.append([e])
+
+    def apply_day(block: List[Dict[str, Any]], d: date) -> None:
+        ds = d.isoformat()
+        for x in block:
+            x["date_of_workout"] = ds
+
+    if len(blocks) == 1:
+        n_days = min(14, max(1, len(entries)))
+        for i, chunk in enumerate(_split_evenly(entries, n_days)):
+            apply_day(chunk, start + timedelta(days=i))
+        return
+
+    for i, block in enumerate(blocks):
+        apply_day(block, start + timedelta(days=min(i, 13)))
 
 
 class GeminiClient(BaseGeminiClient):
@@ -94,7 +150,12 @@ class GeminiClient(BaseGeminiClient):
             ]
             return fallback[:count]
 
-    def generate_two_week_fitness_plan(self, health_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def generate_two_week_fitness_plan(
+        self,
+        health_data: Dict[str, Any],
+        *,
+        plan_start_date: Optional[date] = None,
+    ) -> List[Dict[str, Any]]:
         """
         Generate a 2-week fitness plan based on the user's health profile.
 
@@ -102,10 +163,16 @@ class GeminiClient(BaseGeminiClient):
         flow: we ask Gemini for structured JSON and normalise it into a list of
         plain dicts with stable keys that the fitness_plan module expects.
         """
+        start = plan_start_date or date.today()
+        last = start + timedelta(days=13)
         prompt = (
             "You are a fitness planner. Based on the following user profile, generate a "
-            "2-week workout plan as JSON ONLY. Each entry should include:\n"
-            "  - date_of_workout (ISO date string, e.g. 2026-03-01)\n"
+            "2-week workout plan as JSON ONLY (a JSON array). "
+            f"Schedule every workout on one of these 14 consecutive calendar days only: "
+            f"from {start.isoformat()} through {last.isoformat()} (inclusive). "
+            "Do not use any other dates, years, or past months — only those dates.\n"
+            "Each array entry should include:\n"
+            "  - date_of_workout (ISO date YYYY-MM-DD, must be one of the 14 days above)\n"
             "  - exercise_name\n"
             "  - exercise_description\n"
             "  - rep_count (number, e.g. 10)\n"
@@ -170,6 +237,7 @@ class GeminiClient(BaseGeminiClient):
                         else None,
                     }
                 )
+            _renormalize_fitness_plan_dates(out, start)
             return out
         except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
             raise Exception(f"Failed to parse fitness plan from model: {e}") from e

--- a/app/fitness/plan_generation.py
+++ b/app/fitness/plan_generation.py
@@ -5,6 +5,7 @@ Plan generation logic (no separate REST blueprint).
 """
 from __future__ import annotations
 
+from datetime import date
 from typing import Any, Dict, List, Tuple
 
 from flask import jsonify
@@ -57,7 +58,9 @@ def generate_two_week_plan_and_save(user_id: str) -> Tuple[Any, int]:
         ), 400
 
     gemini = GeminiClient()
-    plan_entries = gemini.generate_two_week_fitness_plan(health_dict)
+    plan_entries = gemini.generate_two_week_fitness_plan(
+        health_dict, plan_start_date=date.today()
+    )
     if not plan_entries:
         return jsonify({"error": "Could not generate plan", "bullet_points": [], "fitness_plans": []}), 422
 

--- a/tests/test_fitness_plan_dates.py
+++ b/tests/test_fitness_plan_dates.py
@@ -1,0 +1,35 @@
+"""Tests for remapping LLM fitness plan dates to the generation start date."""
+
+from datetime import date, timedelta
+
+from app.chat_module.gemini_client import _renormalize_fitness_plan_dates
+
+
+def test_renormalize_maps_wrong_year_blocks_to_consecutive_days():
+    base = date(2026, 4, 1)
+    entries = [
+        {"date_of_workout": "2024-01-01", "exercise_name": "A"},
+        {"date_of_workout": "2024-01-01", "exercise_name": "B"},
+        {"date_of_workout": "2024-01-02", "exercise_name": "C"},
+    ]
+    _renormalize_fitness_plan_dates(entries, base)
+    assert entries[0]["date_of_workout"] == base.isoformat()
+    assert entries[1]["date_of_workout"] == base.isoformat()
+    assert entries[2]["date_of_workout"] == (base + timedelta(days=1)).isoformat()
+
+
+def test_renormalize_single_flat_date_splits_one_entry_per_day_when_possible():
+    base = date(2026, 4, 4)
+    entries = [{"date_of_workout": "2025-06-01", "exercise_name": f"E{i}"} for i in range(4)]
+    _renormalize_fitness_plan_dates(entries, base)
+    for i, e in enumerate(entries):
+        assert e["date_of_workout"] == (base + timedelta(days=i)).isoformat()
+
+
+def test_renormalize_caps_extra_blocks_at_day_14():
+    base = date(2026, 1, 1)
+    entries = [{"date_of_workout": f"2020-01-{i+1:02d}", "exercise_name": str(i)} for i in range(16)]
+    _renormalize_fitness_plan_dates(entries, base)
+    assert entries[13]["date_of_workout"] == (base + timedelta(days=13)).isoformat()
+    assert entries[14]["date_of_workout"] == (base + timedelta(days=13)).isoformat()
+    assert entries[15]["date_of_workout"] == (base + timedelta(days=13)).isoformat()


### PR DESCRIPTION
This PR fixes inconsistent dates in generated fitness plans by anchoring them to a provided start date (default: today). It adds a normalization step that remaps model outputs to consecutive 14 days while preserving grouping. Updates include prompt constraints, date normalization logic, and tests covering edge cases like stale years and overflow beyond 14 days