### PR TITLE
fix(mobile): safe areas, menu taps, and gesture root on Android/iOS

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,6 +1,8 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator, CardStyleInterpolators } from "@react-navigation/stack";
 import { StatusBar } from "expo-status-bar";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import LoginScreen from "./src/screens/LoginScreen";
 import SignupScreen from "./src/screens/SignupScreen";
@@ -18,63 +20,65 @@ const Stack = createStackNavigator();
 
 export default function App() {
   return (
-    <>
-      <StatusBar style="light" />
-      <NavigationContainer>
-        <Stack.Navigator
-          initialRouteName="Login"
-          screenOptions={{
-            headerShown: false,
-            gestureEnabled: true,
-            cardStyle: { backgroundColor: "#4c1d95" },
-            cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-            transitionSpec: {
-              open: {
-                animation: "timing",
-                config: {
-                  duration: 280,
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <StatusBar style="light" />
+        <NavigationContainer>
+          <Stack.Navigator
+            initialRouteName="Login"
+            screenOptions={{
+              headerShown: false,
+              gestureEnabled: true,
+              cardStyle: { backgroundColor: "#4c1d95" },
+              cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
+              transitionSpec: {
+                open: {
+                  animation: "timing",
+                  config: {
+                    duration: 280,
+                  },
+                },
+                close: {
+                  animation: "timing",
+                  config: {
+                    duration: 220,
+                  },
                 },
               },
-              close: {
-                animation: "timing",
-                config: {
-                  duration: 220,
-                },
-              },
-            },
-          }}
-        >
-          <Stack.Screen name="Login" component={LoginScreen} />
-          <Stack.Screen name="Signup" component={SignupScreen} />
-          <Stack.Screen name="Chat" component={ChatScreen} />
-          <Stack.Screen name="Plan" component={PlanScreen} />
-          <Stack.Screen name="ChatBot" component={ChatBotScreen} />
-          <Stack.Screen name="Dashboard" component={DashboardScreen} />
-          <Stack.Screen name="Insights" component={InsightsScreen} />
-          <Stack.Screen name="Snapshot" component={SnapshotScreen} />
-          <Stack.Screen
-            name="RecordVideo"
-            component={RecordVideoScreen}
-            options={{
-              cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
             }}
-          />
-          <Stack.Screen
-            name="ExerciseSelect"
-            component={ExerciseSelectScreen}
-            options={{
-              cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
-            }}
-          />
-          <Stack.Screen
-            name="UserProfile"
-            component={UserProfileScreen}
-            options={{
-              cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
-            }}
-          />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </>
+          >
+            <Stack.Screen name="Login" component={LoginScreen} />
+            <Stack.Screen name="Signup" component={SignupScreen} />
+            <Stack.Screen name="Chat" component={ChatScreen} />
+            <Stack.Screen name="Plan" component={PlanScreen} />
+            <Stack.Screen name="ChatBot" component={ChatBotScreen} />
+            <Stack.Screen name="Dashboard" component={DashboardScreen} />
+            <Stack.Screen name="Insights" component={InsightsScreen} />
+            <Stack.Screen name="Snapshot" component={SnapshotScreen} />
+            <Stack.Screen
+              name="RecordVideo"
+              component={RecordVideoScreen}
+              options={{
+                cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+              }}
+            />
+            <Stack.Screen
+              name="ExerciseSelect"
+              component={ExerciseSelectScreen}
+              options={{
+                cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+              }}
+            />
+            <Stack.Screen
+              name="UserProfile"
+              component={UserProfileScreen}
+              options={{
+                cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+              }}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/mobile/src/components/MenuDropdown.jsx
+++ b/mobile/src/components/MenuDropdown.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { View, Text, StyleSheet, Pressable, Modal } from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
 import { Ionicons } from "@expo/vector-icons";
 import { useNavigation, useRoute } from "@react-navigation/native";
 
@@ -25,11 +26,18 @@ export default function MenuDropdown() {
   };
 
   return (
-    <View>
-      <Pressable style={styles.menuBtn} onPress={() => setOpen(true)}>
+    // RNGH TouchableOpacity: works reliably with @react-navigation/stack gestures on Android.
+    // Outer View: avoid native view collapse removing the hit target in flex rows.
+    <View collapsable={false}>
+      <TouchableOpacity
+        style={styles.menuBtn}
+        onPress={() => setOpen(true)}
+        activeOpacity={0.75}
+        hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+      >
         <Text style={styles.menuText}>Menu</Text>
         <Ionicons name="chevron-down" size={14} color="rgba(255,255,255,0.9)" />
-      </Pressable>
+      </TouchableOpacity>
 
       <Modal
         visible={open}

--- a/mobile/src/screens/ChatBotScreen.jsx
+++ b/mobile/src/screens/ChatBotScreen.jsx
@@ -6,12 +6,12 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
-  SafeAreaView,
   StyleSheet,
   Text,
   TextInput,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { chatAPI } from "../services/api";
 import MenuDropdown from "../components/MenuDropdown";
 
@@ -194,27 +194,29 @@ export default function ChatBotScreen({ route }) {
       colors={["#7c3aed", "#6366f1", "#4c1d95"]}
       style={styles.gradient}
     >
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView style={styles.safe} edges={["top", "left", "right"]}>
         <KeyboardAvoidingView
           style={styles.safe}
           behavior={Platform.OS === "ios" ? "padding" : undefined}
           keyboardVerticalOffset={Platform.OS === "ios" ? 8 : 0}
         >
-          <View style={styles.card}>
-            <View style={styles.topBar}>
-              <Text style={styles.screenTitle}>ChatBot Screen</Text>
-              <MenuDropdown />
-            </View>
+          <View style={styles.outerHeader}>
+            <Text style={styles.screenTitle}>ChatBot Screen</Text>
+            <MenuDropdown />
+          </View>
 
+          <View style={styles.card}>
             {error ? <Text style={styles.errorText}>{error}</Text> : null}
 
             <FlatList
               ref={listRef}
+              style={{ flex: 1 }}
               data={messages}
               keyExtractor={(item) => item.id}
               renderItem={renderItem}
               contentContainerStyle={styles.listContent}
               showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
               onContentSizeChange={scrollToBottom}
             />
 
@@ -249,10 +251,22 @@ const styles = StyleSheet.create({
   gradient: { flex: 1 },
   safe: { flex: 1 },
 
+  outerHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginHorizontal: 16,
+    marginTop: 4,
+    paddingBottom: 8,
+    paddingHorizontal: 4,
+    zIndex: 20,
+    elevation: 20,
+  },
+
   card: {
     flex: 1,
     marginHorizontal: 16,
-    marginTop: 10,
+    marginTop: 0,
     marginBottom: 14,
     borderRadius: 28,
     paddingTop: 12,
@@ -261,14 +275,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "rgba(255,255,255,0.18)",
     overflow: "hidden",
-  },
-
-  topBar: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: 6,
-    paddingBottom: 10,
   },
 
   errorText: {

--- a/mobile/src/screens/ExerciseSelectScreen.jsx
+++ b/mobile/src/screens/ExerciseSelectScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
-import { View, Text, StyleSheet, FlatList, Image, Pressable, SafeAreaView } from "react-native";
+import { View, Text, StyleSheet, FlatList, Image, Pressable } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { Ionicons } from "@expo/vector-icons";
 
@@ -116,7 +117,7 @@ export default function ExerciseSelectScreen({ navigation }) {
       end={{ x: 0.85, y: 0.95 }}
       style={styles.gradient}
     >
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView style={styles.safe} edges={["top", "left", "right", "bottom"]}>
         <View style={styles.card}>
           <View style={styles.topRow}>
             <Pressable style={styles.backBtn} onPress={() => navigation.goBack()}>

--- a/mobile/src/screens/RecordVideoScreen.jsx
+++ b/mobile/src/screens/RecordVideoScreen.jsx
@@ -8,12 +8,12 @@ import {
   ActivityIndicator,
   Alert,
   Pressable,
-  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { cvAPI } from "../services/api";
 
 export default function UploadExerciseScreen({ navigation, route }) {
@@ -110,13 +110,14 @@ export default function UploadExerciseScreen({ navigation, route }) {
   const step2Done = !!videoFile;
 
   return (
-    <SafeAreaView style={styles.safe}>
-      <LinearGradient
-        colors={["#4C76D6", "#8E5AAE"]}
-        start={{ x: 0.15, y: 0.1 }}
-        end={{ x: 0.85, y: 0.95 }}
-        style={styles.gradient}
-      >
+    <LinearGradient
+      colors={["#4C76D6", "#8E5AAE"]}
+      start={{ x: 0.15, y: 0.1 }}
+      end={{ x: 0.85, y: 0.95 }}
+      style={styles.gradient}
+    >
+      {/* Must close </SafeAreaView> before </LinearGradient> (SafeAreaView is inside the gradient). */}
+      <SafeAreaView style={styles.safe} edges={["top", "left", "right", "bottom"]}>
         <View style={styles.shell}>
           <ScrollView
             style={{ flex: 1 }}
@@ -288,14 +289,14 @@ export default function UploadExerciseScreen({ navigation, route }) {
             </Pressable>
           </View>
         </View>
-      </LinearGradient>
-    </SafeAreaView>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: "#4C76D6" },
   gradient: { flex: 1 },
+  safe: { flex: 1, backgroundColor: "transparent" },
 
   shell: {
     flex: 1,

--- a/mobile/src/screens/SnapshotScreen.jsx
+++ b/mobile/src/screens/SnapshotScreen.jsx
@@ -8,13 +8,13 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
-  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Calendar } from "react-native-calendars";
 import MenuDropdown from "../components/MenuDropdown";
 import { chatAPI } from "../services/api";
@@ -153,17 +153,18 @@ export default function SnapshotScreen({ navigation }) {
       colors={["#7c3aed", "#6366f1", "#4c1d95"]}
       style={styles.bg}
     >
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView style={styles.safe} edges={["top", "left", "right"]}>
         <KeyboardAvoidingView
           style={{ flex: 1 }}
           behavior={Platform.OS === "ios" ? "padding" : undefined}
         >
-          <View style={styles.card}>
-            <View style={styles.topBar}>
-              <Text style={styles.topLeftLabel}>Today's Snapshot</Text>
-              <MenuDropdown />
-            </View>
+          {/* Header outside the card: overflow:hidden on the card breaks Android touches on in-card controls */}
+          <View style={styles.outerHeader}>
+            <Text style={styles.topLeftLabel}>Today's Snapshot</Text>
+            <MenuDropdown />
+          </View>
 
+          <View style={styles.card}>
             {userId ? (
               <Text style={styles.userHint} numberOfLines={1}>
                 User: {userId}
@@ -171,8 +172,11 @@ export default function SnapshotScreen({ navigation }) {
             ) : null}
 
             <ScrollView
+              style={{ flex: 1 }}
               showsVerticalScrollIndicator={false}
               contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+              nestedScrollEnabled
             >
               <Text style={styles.title}>Workout Snapshot</Text>
               {planName ? (
@@ -329,7 +333,7 @@ export default function SnapshotScreen({ navigation }) {
               )}
             </ScrollView>
 
-            <View style={styles.promptWrap}>
+            <View style={styles.promptWrap} pointerEvents="box-none">
               <View style={styles.promptPill}>
                 <TextInput
                   value={prompt}
@@ -356,10 +360,22 @@ const styles = StyleSheet.create({
   safe: { flex: 1 },
   bg: { flex: 1 },
 
+  outerHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginHorizontal: 16,
+    marginTop: 4,
+    paddingBottom: 8,
+    paddingHorizontal: 4,
+    zIndex: 20,
+    elevation: 20,
+  },
+
   card: {
     flex: 1,
     marginHorizontal: 16,
-    marginTop: 10,
+    marginTop: 0,
     marginBottom: 14,
     borderRadius: 28,
     paddingTop: 10,
@@ -370,13 +386,6 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
 
-  topBar: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: 6,
-    paddingBottom: 8,
-  },
   topLeftLabel: {
     color: "rgba(255,255,255,0.60)",
     fontSize: 12,


### PR DESCRIPTION
- Wrap app in SafeAreaProvider + GestureHandlerRootView
- ChatBot/Snapshot: safe-area-context SafeAreaView, header outside card
- MenuDropdown: RNGH TouchableOpacity + hitSlop
- Record/Exercise select: gradient outside SafeAreaView for correct top inset
- Document RecordVideo JSX close order
