### PR TITLE
Security/130 implement backend file size and format validation for video uploads

### DIFF
--- a/app/exercises/routes.py
+++ b/app/exercises/routes.py
@@ -4,6 +4,7 @@ from flask import Blueprint, request, jsonify
 import boto3
 from dotenv import load_dotenv
 import os
+import mimetypes
 from werkzeug.utils import secure_filename
 from .openpose import user_output
 
@@ -24,6 +25,17 @@ s3 = boto3.client(
 exercises_bp = Blueprint('exercises', __name__)
 EXERCISES_DIR = os.path.dirname(os.path.abspath(__file__))
 VIDEO_IN_DIR = os.path.join(EXERCISES_DIR, 'video_in')
+
+MAX_VIDEO_UPLOAD_SIZE_MB = int(os.getenv('MAX_VIDEO_UPLOAD_SIZE_MB', '50'))
+MAX_VIDEO_UPLOAD_SIZE_BYTES = MAX_VIDEO_UPLOAD_SIZE_MB * 1024 * 1024
+ALLOWED_VIDEO_MIME_TYPES = {
+    'video/mp4',
+    'video/quicktime',
+}
+ALLOWED_VIDEO_EXTENSIONS = {
+    '.mp4',
+    '.mov',
+}
 
 # Might have to map frontend naming to EXERCISE PRESETS
 # IMPORTANT #
@@ -83,6 +95,56 @@ def parse_user_video(video_file, exercise, user_id):
     }
 
 
+def _get_upload_size_bytes(video):
+    stream = video.stream
+    current_position = stream.tell()
+    stream.seek(0, os.SEEK_END)
+    size_bytes = stream.tell()
+    stream.seek(current_position)
+    return size_bytes
+
+
+def _validate_video_upload(video):
+    filename = secure_filename(video.filename or 'upload.mp4')
+
+    extension = os.path.splitext(filename)[1].lower()
+    if extension not in ALLOWED_VIDEO_EXTENSIONS:
+        return {
+            'error': 'unsupported video file extension',
+            'allowed_extensions': sorted(ALLOWED_VIDEO_EXTENSIONS),
+            'received_extension': extension or None,
+        }, 415
+
+    mime_type = (video.mimetype or '').strip().lower()
+    if not mime_type:
+        guessed_mime_type, _ = mimetypes.guess_type(filename)
+        mime_type = (guessed_mime_type or '').lower()
+
+    if mime_type not in ALLOWED_VIDEO_MIME_TYPES:
+        return {
+            'error': 'unsupported video MIME type',
+            'allowed_mime_types': sorted(ALLOWED_VIDEO_MIME_TYPES),
+            'received_mime_type': mime_type or None,
+        }, 415
+
+    size_bytes = _get_upload_size_bytes(video)
+    if size_bytes <= 0:
+        return {
+            'error': 'uploaded video file is empty',
+        }, 400
+
+    if size_bytes > MAX_VIDEO_UPLOAD_SIZE_BYTES:
+        return {
+            'error': 'uploaded video file exceeds maximum allowed size',
+            'max_size_bytes': MAX_VIDEO_UPLOAD_SIZE_BYTES,
+            'received_size_bytes': size_bytes,
+        }, 413
+
+    # Ensure downstream save/read starts from the beginning of the stream.
+    video.stream.seek(0)
+    return None, None
+
+
 @exercises_bp.route('/analyze', methods=['POST'])
 def analyze_video():
     print(f"[CV] /analyze received files={list(request.files.keys())}, form_keys={list(request.form.keys())}")
@@ -104,6 +166,10 @@ def analyze_video():
             'received_files': list(request.files.keys()),
             'received_form_fields': list(request.form.keys()),
         }), 400
+
+    validation_error, status_code = _validate_video_upload(video)
+    if validation_error:
+        return jsonify(validation_error), status_code
 
     os.makedirs(VIDEO_IN_DIR, exist_ok=True)
     filename = secure_filename(video.filename or 'upload.mp4')

--- a/tests/test_cv_upload_validation.py
+++ b/tests/test_cv_upload_validation.py
@@ -1,0 +1,113 @@
+import io
+import sys
+import types
+
+import pytest
+
+# Avoid importing heavyweight CV dependencies for route-level validation tests.
+openpose_stub = types.ModuleType("app.exercises.openpose")
+openpose_stub.user_output = lambda *_args, **_kwargs: None
+sys.modules.setdefault("app.exercises.openpose", openpose_stub)
+
+import app.main as main_module
+import app.exercises.routes as routes_module
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    monkeypatch.setattr(main_module, "load_fitness_benchmarks", lambda: {"strength": {"example": 1}})
+    monkeypatch.setattr(routes_module, "VIDEO_IN_DIR", str(tmp_path))
+
+    app = main_module.create_app()
+    app.testing = True
+    return app
+
+
+def test_analyze_video_rejects_unsupported_mime(monkeypatch, app, tmp_path):
+    parse_mock_called = {"called": False}
+
+    def fake_parse(*_args, **_kwargs):
+        parse_mock_called["called"] = True
+        return {}
+
+    monkeypatch.setattr(routes_module, "parse_user_video", fake_parse)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/cv/analyze",
+        data={
+            "exercise": "bicep_curl",
+            "user_id": "user123",
+            "video": (io.BytesIO(b"not-a-video"), "clip.mp4", "text/plain"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 415
+    payload = response.get_json()
+    assert payload["error"] == "unsupported video MIME type"
+    assert parse_mock_called["called"] is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_analyze_video_rejects_oversized_upload(monkeypatch, app, tmp_path):
+    monkeypatch.setattr(routes_module, "MAX_VIDEO_UPLOAD_SIZE_BYTES", 8)
+
+    parse_mock_called = {"called": False}
+
+    def fake_parse(*_args, **_kwargs):
+        parse_mock_called["called"] = True
+        return {}
+
+    monkeypatch.setattr(routes_module, "parse_user_video", fake_parse)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/cv/analyze",
+        data={
+            "exercise": "bicep_curl",
+            "user_id": "user123",
+            "video": (io.BytesIO(b"0123456789"), "clip.mp4", "video/mp4"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 413
+    payload = response.get_json()
+    assert payload["error"] == "uploaded video file exceeds maximum allowed size"
+    assert payload["max_size_bytes"] == 8
+    assert payload["received_size_bytes"] == 10
+    assert parse_mock_called["called"] is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_analyze_video_accepts_valid_upload(monkeypatch, app):
+    expected_output = {
+        "form_score": 92.5,
+        "joint_scores": {"RWrist": 93.0},
+        "feedback": "Great form!",
+    }
+
+    def fake_parse(_filename, _exercise, _user_id):
+        return dict(expected_output)
+
+    monkeypatch.setattr(routes_module, "parse_user_video", fake_parse)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/cv/analyze",
+        data={
+            "exercise": "bicep_curl",
+            "user_id": "user123",
+            "video": (io.BytesIO(b"01234567"), "clip.mp4", "video/mp4"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["form_score"] == expected_output["form_score"]
+    assert payload["joint_scores"] == expected_output["joint_scores"]
+    assert payload["feedback"] == expected_output["feedback"]
+    assert payload["exercise"] == "bicep_curl"
+    assert payload["user_id"] == "user123"


### PR DESCRIPTION
Update the system to validate uploaded videos by adding file size restrictions and MIME type restrictions (to only supported video formats), add rejection mechanisms for uploads that fail before reaching S3, and add error responses for invalid uploads. Added unit testing & ran existing tests on code to verify it didn't break current functionality