### PR TITLE
Security/129 implement rate limiting for video upload endpoint

### DIFF
--- a/app/exercises/routes.py
+++ b/app/exercises/routes.py
@@ -28,8 +28,12 @@ exercises_bp = Blueprint('exercises', __name__)
 EXERCISES_DIR = os.path.dirname(os.path.abspath(__file__))
 VIDEO_IN_DIR = os.path.join(EXERCISES_DIR, 'video_in')
 
-CV_UPLOAD_USER_RATE_LIMIT = os.getenv('CV_UPLOAD_USER_RATE_LIMIT', '10 per minute')
-CV_UPLOAD_IP_RATE_LIMIT = os.getenv('CV_UPLOAD_IP_RATE_LIMIT', '30 per minute')
+def _get_cv_upload_user_rate_limit():
+    return os.getenv('CV_UPLOAD_USER_RATE_LIMIT', '10 per minute')
+
+
+def _get_cv_upload_ip_rate_limit():
+    return os.getenv('CV_UPLOAD_IP_RATE_LIMIT', '30 per minute')
 
 # Might have to map frontend naming to EXERCISE PRESETS
 # IMPORTANT #
@@ -100,8 +104,8 @@ def _upload_user_rate_limit_key():
 
 
 @exercises_bp.route('/analyze', methods=['POST'])
-@limiter.limit(CV_UPLOAD_IP_RATE_LIMIT, key_func=get_remote_address)
-@limiter.limit(CV_UPLOAD_USER_RATE_LIMIT, key_func=_upload_user_rate_limit_key)
+@limiter.limit(_get_cv_upload_ip_rate_limit, key_func=get_remote_address)
+@limiter.limit(_get_cv_upload_user_rate_limit, key_func=_upload_user_rate_limit_key)
 def analyze_video():
     print(f"[CV] /analyze received files={list(request.files.keys())}, form_keys={list(request.form.keys())}")
 

--- a/app/exercises/routes.py
+++ b/app/exercises/routes.py
@@ -5,7 +5,10 @@ import boto3
 from dotenv import load_dotenv
 import os
 from werkzeug.utils import secure_filename
+from flask_limiter.util import get_remote_address
 from .openpose import user_output
+from app.auth_module.utils import resolve_authenticated_user_id
+from app.rate_limit import limiter
 
 load_dotenv()
 
@@ -24,6 +27,9 @@ s3 = boto3.client(
 exercises_bp = Blueprint('exercises', __name__)
 EXERCISES_DIR = os.path.dirname(os.path.abspath(__file__))
 VIDEO_IN_DIR = os.path.join(EXERCISES_DIR, 'video_in')
+
+CV_UPLOAD_USER_RATE_LIMIT = os.getenv('CV_UPLOAD_USER_RATE_LIMIT', '10 per minute')
+CV_UPLOAD_IP_RATE_LIMIT = os.getenv('CV_UPLOAD_IP_RATE_LIMIT', '30 per minute')
 
 # Might have to map frontend naming to EXERCISE PRESETS
 # IMPORTANT #
@@ -83,7 +89,19 @@ def parse_user_video(video_file, exercise, user_id):
     }
 
 
+def _upload_user_rate_limit_key():
+    user_id = resolve_authenticated_user_id()
+    if user_id:
+        return f"user:{user_id}"
+
+    forwarded_for = (request.headers.get('X-Forwarded-For') or '').split(',')[0].strip()
+    remote_ip = forwarded_for or request.remote_addr or 'unknown'
+    return f"anon:{remote_ip}"
+
+
 @exercises_bp.route('/analyze', methods=['POST'])
+@limiter.limit(CV_UPLOAD_IP_RATE_LIMIT, key_func=get_remote_address)
+@limiter.limit(CV_UPLOAD_USER_RATE_LIMIT, key_func=_upload_user_rate_limit_key)
 def analyze_video():
     print(f"[CV] /analyze received files={list(request.files.keys())}, form_keys={list(request.form.keys())}")
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.chat_module.routes import chat_bp as chat_module_bp
 from app.fitness.benchmark_loader import load_fitness_benchmarks
 from app.logger import get_logger
 from app.exercises.routes import exercises_bp
+from app.rate_limit import init_rate_limiter
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -64,6 +65,7 @@ def create_app():
         "origins": cors_origins,
     }
     CORS(app, resources={r"/auth/*": cors_opts, r"/api/*": dict(cors_opts)})
+    init_rate_limiter(app)
 
     db.init_app(app)
 

--- a/app/rate_limit.py
+++ b/app/rate_limit.py
@@ -1,0 +1,43 @@
+import os
+
+from flask import jsonify, request
+from flask_limiter import Limiter
+from flask_limiter.errors import RateLimitExceeded
+from flask_limiter.util import get_remote_address
+
+from app.auth_module.utils import resolve_authenticated_user_id
+from app.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+_storage_uri = os.getenv("RATELIMIT_STORAGE_URI", "memory://")
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=[],
+    storage_uri=_storage_uri,
+    headers_enabled=True,
+)
+
+
+def _rate_limit_exceeded_handler(error: RateLimitExceeded):
+    user_id = resolve_authenticated_user_id() or "anonymous"
+    ip_address = request.headers.get("X-Forwarded-For", request.remote_addr)
+    logger.warning(
+        "Rate limit exceeded path=%s method=%s user_id=%s ip=%s limit=%s",
+        request.path,
+        request.method,
+        user_id,
+        ip_address,
+        str(error.description),
+    )
+    return jsonify({
+        "error": "Rate limit exceeded",
+        "detail": str(error.description),
+    }), 429
+
+
+def init_rate_limiter(app):
+    limiter.init_app(app)
+    app.register_error_handler(429, _rate_limit_exceeded_handler)

--- a/doc/backend-api-inventory.md
+++ b/doc/backend-api-inventory.md
@@ -23,6 +23,29 @@ This document freezes the HTTP surface of the Flask app as of the inventory pass
 | POST | `/api/chat/plan` | `PlanScreen.js`, `SnapshotScreen.jsx` via `chatAPI.generatePlan` |
 | POST | `/api/cv/analyze` | `RecordVideoScreen.jsx` via `cvAPI.analyzeVideo` |
 
+### Upload endpoint limits
+
+`POST /api/cv/analyze` is rate-limited with Flask-Limiter using both identities:
+
+- Authenticated user key: `X-User-Id` / resolved session identity (default `10 per minute`)
+- IP address key: client remote IP (default `30 per minute`)
+
+Environment variables:
+
+- `CV_UPLOAD_USER_RATE_LIMIT` (for example: `10 per minute`)
+- `CV_UPLOAD_IP_RATE_LIMIT` (for example: `30 per minute`)
+
+When a request exceeds either limit, the API returns HTTP `429` with:
+
+```json
+{
+	"error": "Rate limit exceeded",
+	"detail": "<limit description>"
+}
+```
+
+Violations are logged with request path, method, user identity, IP, and exceeded limit.
+
 `chatAPI.sendMessage` in `api.js` maps to `POST /api/chat` but **no screen imports it**; only `sendChatbotMessage` is used. That is unused client surface, not proof the backend route is unused globally (web uses `POST /api/chat`).
 
 ---

--- a/doc/how-to.md
+++ b/doc/how-to.md
@@ -148,10 +148,18 @@ To securely create and store all necessary external credentials and variables fo
    SUPABASE_URL=url_here
    SUPABASE_ANON_KEY=anon_key_here
    ```
-5. Save the edited `.env` file and ensure it is included in the `.gitignore` file so credentials are never committed to version control.
+5. Add optional CV upload rate-limit settings:
+   ```
+   CV_UPLOAD_USER_RATE_LIMIT=10 per minute
+   CV_UPLOAD_IP_RATE_LIMIT=30 per minute
+   ```
+6. Save the edited `.env` file and ensure it is included in the `.gitignore` file so credentials are never committed to version control.
 
 #### Expected Result
 The `.env` file is correctly populated and the application can run with proper access to all external services needed.
+
+#### Note on upload limits
+If a client exceeds upload frequency limits on `POST /api/cv/analyze`, the backend returns HTTP `429` (`Rate limit exceeded`).
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==3.0.3
 Flask-SQLAlchemy==3.1.1
 Flask-CORS==4.0.0
+Flask-Limiter==3.8.0
 
 Werkzeug==3.0.3
 python-dotenv==1.0.1

--- a/tests/test_cv_rate_limit.py
+++ b/tests/test_cv_rate_limit.py
@@ -1,0 +1,95 @@
+import io
+import os
+import sys
+import types
+
+import pytest
+
+# Keep limits low in tests so 429 behavior is exercised quickly.
+os.environ.setdefault("CV_UPLOAD_USER_RATE_LIMIT", "2 per minute")
+os.environ.setdefault("CV_UPLOAD_IP_RATE_LIMIT", "5 per minute")
+
+# Avoid importing heavyweight CV dependencies for route-level tests.
+openpose_stub = types.ModuleType("app.exercises.openpose")
+openpose_stub.user_output = lambda *_args, **_kwargs: (0.8, {"RWrist": 0.9}, {}, {}, {}, "OK")
+sys.modules.setdefault("app.exercises.openpose", openpose_stub)
+
+import app.main as main_module
+import app.exercises.routes as routes_module
+import app.rate_limit as rate_limit_module
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    monkeypatch.setattr(main_module, "load_fitness_benchmarks", lambda: {"strength": {"example": 1}})
+    monkeypatch.setattr(routes_module, "VIDEO_IN_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        routes_module,
+        "parse_user_video",
+        lambda _filename, _exercise, _user_id: {
+            "form_score": 90.0,
+            "joint_scores": {"RWrist": 90.0},
+            "feedback": "Good",
+        },
+    )
+
+    app = main_module.create_app()
+    app.testing = True
+    return app
+
+
+def _post_upload(client, *, user_id, ip_address):
+    return client.post(
+        "/api/cv/analyze",
+        data={
+            "exercise": "bicep_curl",
+            "user_id": user_id,
+            "video": (io.BytesIO(b"tiny-bytes"), "clip.mp4", "video/mp4"),
+        },
+        content_type="multipart/form-data",
+        headers={"X-User-Id": user_id},
+        environ_base={"REMOTE_ADDR": ip_address},
+    )
+
+
+def test_upload_rate_limit_per_authenticated_user(app):
+    client = app.test_client()
+
+    r1 = _post_upload(client, user_id="user-a", ip_address="198.51.100.10")
+    r2 = _post_upload(client, user_id="user-a", ip_address="198.51.100.10")
+    r3 = _post_upload(client, user_id="user-a", ip_address="198.51.100.10")
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r3.status_code == 429
+    payload = r3.get_json()
+    assert payload["error"] == "Rate limit exceeded"
+
+
+def test_upload_rate_limit_per_ip_address(app):
+    client = app.test_client()
+
+    responses = []
+    for i in range(6):
+        responses.append(_post_upload(client, user_id=f"user-{i}", ip_address="203.0.113.20"))
+
+    assert responses[0].status_code == 200
+    assert responses[4].status_code == 200
+    assert responses[5].status_code == 429
+
+
+def test_rate_limit_violation_is_logged(app, monkeypatch):
+    warnings = []
+
+    def _fake_warning(msg, *args):
+        warnings.append(msg % args)
+
+    monkeypatch.setattr(rate_limit_module.logger, "warning", _fake_warning)
+
+    client = app.test_client()
+    _post_upload(client, user_id="log-user", ip_address="192.0.2.99")
+    _post_upload(client, user_id="log-user", ip_address="192.0.2.99")
+    limited = _post_upload(client, user_id="log-user", ip_address="192.0.2.99")
+
+    assert limited.status_code == 429
+    assert any("Rate limit exceeded" in message for message in warnings)


### PR DESCRIPTION
Rate limiting added to Flask API upload endpoints to restrict number of uploads allowed per user & per IP address by integrating Flask-Limited into backend, configuring rate limits for video upload endpoint, adding logging for rate limit violations and updating API documentation to reflect upload limits. Unit testing added to ensure current functionality is not broken